### PR TITLE
[STYLE] 디자인 토큰 적용 - Figma 색상 및 Pretendard 폰트 반영

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -212,10 +212,10 @@ export default function App() {
                 fontSize: "0.8rem",
                 textTransform: "none",
                 fontWeight: 600,
-                background: "#0066CC",
+                background: "var(--accent)",
                 color: "#fff",
                 border: "none",
-                boxShadow: "0 2px 8px rgba(0, 102, 204, 0.2)",
+                boxShadow: "0 2px 8px rgba(47, 47, 228, 0.2)",
               }}
             >
               <span

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -28,7 +28,7 @@ export default function Footer() {
         color: "var(--fg-secondary)",
         fontSize: "13px",
         width: "100%",
-        fontFamily: "'NanumSquare', -apple-system, sans-serif",
+        fontFamily: "'Pretendard', -apple-system, sans-serif",
       }}
     >
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@2.0/nanumsquare.css');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css');
 @import "tailwindcss";
 
 @theme {
@@ -12,7 +12,7 @@
   --color-danger: #FF4B4B;
   --color-border: #E8EBEF;
 
-  --font-sans: 'NanumSquare', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-sans: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 
   --radius: 0px;
   --radius-sm: 0px;
@@ -44,7 +44,7 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--fg);
-  font-family: 'NanumSquare', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -438,7 +438,7 @@ h3 {
 .brand-link {
   color: var(--accent);
   text-decoration: none;
-  font-family: 'Arial Black', 'Segoe UI Black', 'NanumSquare', sans-serif;
+  font-family: 'Arial Black', 'Segoe UI Black', 'Pretendard', sans-serif;
   font-weight: 900;
   font-size: 32px;
   letter-spacing: -1.5px;

--- a/src/index.css
+++ b/src/index.css
@@ -716,7 +716,7 @@ h3 {
 }
 
 .search-submit-btn {
-  background: #0066CC;
+  background: var(--accent);
   color: white;
   border: none;
   padding: 0 40px;

--- a/src/index.css
+++ b/src/index.css
@@ -2,15 +2,23 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg: #F5F6F8;
+  --color-primary: #2F2FE4;
+  --color-secondary-001: #162E93;
+  --color-secondary-002: #1A1953;
+  --color-black: #080616;
+  --color-gray: #A2A0A0;
+  --color-divider: #DADADA;
+  --color-white: #FAFAFA;
+
+  --color-bg: #FAFAFA;
   --color-card: #FFFFFF;
-  --color-fg: #222222;
-  --color-fg-secondary: #666666;
-  --color-accent: #004C99;
-  --color-accent-dark: #00366D;
-  --color-muted: #888888;
+  --color-fg: #080616;
+  --color-fg-secondary: #A2A0A0;
+  --color-accent: #2F2FE4;
+  --color-accent-dark: #162E93;
+  --color-muted: #A2A0A0;
   --color-danger: #FF4B4B;
-  --color-border: #E8EBEF;
+  --color-border: #DADADA;
 
   --font-sans: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 
@@ -21,15 +29,24 @@
 }
 
 :root {
-  --bg: #F5F6F8;
+  --primary: #2F2FE4;
+  --secondary-001: #162E93;
+  --secondary-002: #1A1953;
+  --black: #080616;
+  --gray: #A2A0A0;
+  --divider: #DADADA;
+  --white: #FAFAFA;
+
+  --bg: #FAFAFA;
   --card: #FFFFFF;
-  --fg: #222222;
-  --fg-secondary: #666666;
-  --accent: #004C99;
-  --accent-dark: #00366D;
-  --muted: #888888;
+  --fg: #080616;
+  --fg-secondary: #A2A0A0;
+  --accent: #2F2FE4;
+  --accent-dark: #162E93;
+  --muted: #A2A0A0;
   --danger: #FF4B4B;
-  --border: #E8EBEF;
+  --border: #DADADA;
+  --gradient-statra: linear-gradient(90deg, #2F2FE4 0%, #162E93 35.6%, #1A1953 67.8%, #080616 95.7%);
   --radius: 0px;
   --radius-sm: 0px;
   --radius-lg: 0px;


### PR DESCRIPTION
## 🔍 PR 요약

- Figma 디자인 시스템 기반의 색상 토큰과 폰트를 프로젝트에 반영합니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #5 

## 🛠️ 주요 변경 사항

- `src/index.css`: CDN을 NanumSquare → Pretendard로 교체
- `src/index.css`: `@theme` 및 `:root`에 Figma 디자인 토큰 색상 반영
- `src/App.jsx`: 하드코딩 `#0066CC` → `var(--accent)` 교체
- `src/index.css` `.search-submit-btn`: 하드코딩 `#0066CC` → `var(--accent)` 교체
- `src/components/Footer.jsx`: font-family NanumSquare → Pretendard 교체

## 🧠 의도 및 배경

- 디자이너가 확정한 Figma 색상 토큰을 코드베이스에 단일 출처(index.css)로 관리하기 위해 반영
- 하드코딩된 색상값이 산재해 있어 테마 변경 시 일괄 대응이 불가능했던 문제 해결
- `@theme`(Tailwind 유틸리티 클래스)과 `:root`(인라인 스타일·CSS 규칙용 var()) 모두 유지하여 두 방식 모두 지원


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 로그인 버튼 스타일을 새로운 액센트 테마로 업데이트했습니다.
  * 전체 사이트 폰트를 Pretendard로 변경하여 텍스트 렌더링을 개선했습니다.
  * 디자인 토큰 팔레트를 재설계하고 새로운 그래디언트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->