### PR TITLE
[!HOTFIX] Vercel SPA fallback rewrite로 새로고침 404 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- Vercel 운영 환경에서 클라이언트 라우트 새로고침 시 404가 응답되던 문제 해결
- `vercel.json`에 SPA fallback rewrite 추가

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #23

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- `vercel.json` 신규 추가
  ```json
  {
    "rewrites": [
      { "source": "/(.*)", "destination": "/index.html" }
    ]
  }
  ```
- 모든 unmatched 경로를 `/index.html`로 위임 → React Router가 클라이언트 사이드 라우팅 처리

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- SPA(React Router) 특성상 `/payments`, `/matches` 같은 클라이언트 라우트는 빌드 결과물에 실제 정적 파일로 존재하지 않음
- 새로고침은 브라우저가 서버에 실제 HTTP 요청을 보내는 동작이라, Vercel이 해당 경로의 정적 파일을 찾지 못해 404 응답
- 모든 경로를 `index.html`로 fallback하면 SPA가 로드되고 React Router가 URL을 보고 알맞은 페이지를 렌더링

