### PR TITLE
[Release] v1.0.1 - Vercel SPA 새로고침 404 핫픽스

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## 🔍 PR 요약

- v1.0.0 배포 후 발견된 Vercel 환경 SPA 새로고침 404 이슈 핫픽스
- develop의 hotfix 머지(`#23`)를 main으로 반영하는 패치 릴리즈

## 🧾 관련 이슈

- 포함된 작업 이슈: #23 ([!HOTFIX] Vercel 배포 환경에서 새로고침 시 404 발생)

## 🛠️ 주요 변경 사항

- `vercel.json` 신규 추가: 모든 unmatched 경로를 `/index.html`로 SPA fallback rewrite

  ```json
  {
    "rewrites": [
      { "source": "/(.*)", "destination": "/index.html" }
    ]
  }
  ```

## 🧠 의도 및 배경

- v1.0.0 배포 직후, 운영 환경(`https://k-statra-frontend.vercel.app`)에서 헤더 네비게이션을 통한 페이지 이동은 정상 동작하지만, 임의의 클라이언트 라우트(`/payments`, `/matches`, `/my-business` 등)에서 **새로고침 또는 URL 직접 진입** 시 Vercel이 404를 응답하는 문제가 발견됨.
- SPA(React Router) 특성상 클라이언트 라우트는 빌드 결과물에 정적 파일로 존재하지 않으며, Vercel 기본 설정으로는 자동 fallback이 적용되지 않은 상태였음.
- 사용자 입장에서 페이지 새로고침이 곧 "강제 로그아웃 + 에러"로 인식되는 치명적인 UX 결함이므로 즉시 핫픽스 배포 필요.
